### PR TITLE
ENH002 - Filtrar por data medidas de Throughput do GitHub pelo Parser

### DIFF
--- a/genericparser/plugins/dinamic/github.py
+++ b/genericparser/plugins/dinamic/github.py
@@ -84,7 +84,6 @@ class ParserGithub(GenericStaticABC):
                 and (closed_at is None
                 or (closed_at is not None and closed_at >= since)))
 
-
     def _get_throughput(self, base_url, token=None, filters=None):
         values = []
         issues = []

--- a/genericparser/plugins/dinamic/github.py
+++ b/genericparser/plugins/dinamic/github.py
@@ -61,23 +61,46 @@ class ParserGithub(GenericStaticABC):
             return False
 
     def _check_requests(self, base_url, params, values, token=None):
+        results = []
         for value in values:
             url_value = value.replace(" ", "%20")
             url = f"{base_url}/{params}{url_value}"
             response = self._make_request(url, token)
-            if isinstance(response, list) and response:
-                return response
-        return []
+            if response and isinstance(response, list):
+                for result in response:
+                    if result not in results:
+                        results.append(result)
+        return results
+
+    def _is_valid_time(self, value, dates):
+        date_since, date_until = dates
+
+        created_at = datetime.strptime(value["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+        closed_at = datetime.strptime(value["closed_at"], "%Y-%m-%dT%H:%M:%SZ") if value["closed_at"] else None
+        since = datetime.strptime(date_since, "%d/%m/%Y")
+        until = datetime.strptime(date_until, "%d/%m/%Y")
+
+        return ((created_at <= until)
+                and (closed_at is None
+                or (closed_at is not None and closed_at >= since)))
+
 
     def _get_throughput(self, base_url, token=None, filters=None):
         values = []
+        issues = []
         label_list = filters["labels"].split(",") if filters and filters["labels"] else []
-        issues = self._check_requests(
+        dates = filters["dates"].split("-") if filters and filters["dates"] else None
+        response = self._check_requests(
             base_url,
             "issues?state=all&labels=",
             label_list,
             token,
         )
+
+        for issue in response:
+            if dates is None or self._is_valid_time(issue, dates):
+                issues.append(issue)
+
         total_issues = len(issues)
         resolved_issues = sum(1 for issue in issues if issue["state"] == "closed")
 

--- a/tests/mockfiles/expected_return_values.py
+++ b/tests/mockfiles/expected_return_values.py
@@ -7,9 +7,9 @@ EXPECT_EXTRACT_METRICS = {
         "total_builds",
     ],
     "values": [
-        22,
-        17,
-        0.7727272727272727,
+        16,
+        11,
+        0.6875,
         595,
         15,
     ],

--- a/tests/unit_tests/test_github_parser_metrics.py
+++ b/tests/unit_tests/test_github_parser_metrics.py
@@ -34,7 +34,8 @@ def test_extract_method():
         parserObject.extract(**{
             "input_file": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
             "filters": {"labels": "US",
-                        "workflows": ["pages build and deployment"]}
+                        "workflows": ["pages build and deployment"],
+                        "dates": "20/06/2023-15/07/2023"}
         })
         == EXPECT_EXTRACT_METRICS
     )


### PR DESCRIPTION
## Descrição
Atualmente, a utilização da API do Github para buscar as medidas do Throughput buscam por todas as issues do repositório em questão na API do Github. Como melhoria, devemos trazer um parâmetro para limitar essa busca dentro de um período de datas.

[ENH002](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/64)

## Porque este Pull Request é necessário?
Com essa alteração, utilizaremos um parâmetro para realizar a busca correta por todas as issues que serão utilizadas na extração de medidas para o Throughput, limitadas nesse período de tempo.

## Critérios de aceitação

- [x] Após a alteração, a busca deve estar considerando apenas issues que possuam:
    - Data de criação anterior à data final inserida no período
    - Data de fechamento posterior à data inicial inserida no período, caso a data de fechamento exista. Caso não exista, a issue é considerada.
- [x] Deverão haver testes para garantir o funcionamento

Closes #64
