### PR TITLE
Enh001 - Desejo filtrar por data medidas de CI_Feedback do GitHub no CLI, para que eu possa ter as métricas em um período de tempo

### DIFF
--- a/genericparser/plugins/dinamic/github.py
+++ b/genericparser/plugins/dinamic/github.py
@@ -43,7 +43,7 @@ class ParserGithub(GenericStaticABC):
                     continue
 
                 started_at = datetime.fromisoformat(
-                    run["created_at"].replace("Z", "+00:00")
+                    run["run_started_at"].replace("Z", "+00:00")
                 )
                 completed_at = datetime.fromisoformat(
                     run["updated_at"].replace("Z", "+00:00")

--- a/genericparser/plugins/dinamic/github.py
+++ b/genericparser/plugins/dinamic/github.py
@@ -28,6 +28,13 @@ class ParserGithub(GenericStaticABC):
             return True
         if "workflows" in filters and run["name"] not in filters["workflows"]:
             return False
+        if "dates" in filters:
+            dates = filters["dates"].split("-")
+            run_date = datetime.strptime(run["run_started_at"], "%Y-%m-%dT%H:%M:%SZ")
+            start = datetime.strptime(dates[0], "%d/%m/%Y")
+            end = datetime.strptime(dates[1], "%d/%m/%Y")
+            if run_date < start or run_date > end:
+                return False
         return True
 
     def _get_ci_feedback_times(self, base_url, token=None, filters=None):

--- a/tests/mockfiles/expected_return_values.py
+++ b/tests/mockfiles/expected_return_values.py
@@ -10,8 +10,8 @@ EXPECT_EXTRACT_METRICS = {
         16,
         11,
         0.6875,
-        595,
-        15,
+        513,
+        13,
     ],
     "file_paths": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
 }


### PR DESCRIPTION
## Descrição
- Adiciona o filtro por data ao cálculo do ci_feedback_time sum e contagem de builds.
- Atualiza os testes considerando a mudança.
- Resolve: [https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/22](ENH001)
- Muda tempo de início da run para "run_started_at"
- Resolve: [https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/73](BUG014)

## Critérios de aceitação

- [x] Deve existir o parâmetro -fd, significando "filter date", que especifica uma entrada de duas datas que serão levadas como parâmetros para o filtro, sendo essas as datas de início e fim do período de tempo
- [x] O parâmetro -fd deve estar acompanhado por um texto no formato "dd/mm/yyyy-dd/mm/yyyy", representando as duas datas, para ser tratado pelo sistema
- [x] Caso o parâmetro não esteja no formato desejado, o sistema deve retornar um erro seguindo o padrão de mensagens de erro do CLI, com a mensagem: "Error: Dates for filter must be in format 'dd/mm/yyyy-dd/mm/yyyy' "
- [x] Caso o parâmetro -fd esteja correto, mas esteja acompanhado do parâmetro "-o" com valor "sonarqube", o programa deve informar o usuário que o parâmetro -fd deve acompanhar apenas a extração pelo GitHub, com a mensagem de erro "Error: The parameter '-fd' must accompany a github repository output"
- [x] O sistema deve exibir o parâmetro e sua breve explicação ao executar o comando "msgram extract -h", exibindo a descrição "Filter range of dates considered on extraction, with format 'dd/mm/yyyy-dd/mm/yyyy' ", como segue demonstrado no protótipo 1
- [x] Caso comando "msgram extract ..." não esteja acompanhado do parâmetro -fd, o sistema deve continuar a extração considerando todas as informações do repositório, como já é realizado atualmente no sistema
- [x] O sistema deve considerar o filtro para buscar no repositório especificado todas as informações das métricas que são resultado da extração (total de issues, issues resolvidas, total de builds, tempo de builds) dentro do período de tempo especificado

Closes #numero_da_issue